### PR TITLE
Add search param naming and resource creation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,59 @@ next_date = next_date + (current.dst() - next_date.dst())
 
 Do not forget to cover this logic with tests by checking that all time values (hours, minutes, etc) in your range are equal and the range parts quantity is correct
 
+
+#### Create resources via dict not via args
+**Bad**
+```python
+organization = sdk.client.resource(
+  "Organization",
+  name="beda.software",
+  active=False
+)
+```
+
+**Good**
+```python
+organization = sdk.client.resource(
+  "Organization",
+  **{"name": "beda.software", "active": False}
+)
+```
+
+
+#### Use dasherize search parameters names and URL paths in operations
+**Bad**
+```python
+"Encounter.hasInvoice": {
+  "name": "hasInvoice",
+  #...
+},
+```
+
+**Good**
+```python
+"Encounter.hasInvoice": {
+  "name": "has-invoice",
+  #...
+},
+```
+
+**Bad**
+```python
+@sdk.operation(["GET"], ["Resource", {"name": "resource_id"}, "$operation_with_resource"])
+```
+
+or
+
+```python
+@sdk.operation(["GET"], ["Resource", {"name": "resourceId"}, "$operationWithResource"])
+```
+
+**Good**
+```python
+@sdk.operation(["GET"], ["Resource", {"name": "resource-id"}, "$operation-with-resource"])
+```
+
 ### QA, Backend Tests
 
 #### Mocking free functions

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Do not forget to cover this logic with tests by checking that all time values (h
 organization = sdk.client.resource(
   "Organization",
   name="beda.software",
-  active=False
+  active=False,
+  someAttribute="attribute value"
 )
 ```
 
@@ -148,7 +149,7 @@ organization = sdk.client.resource(
 ```python
 organization = sdk.client.resource(
   "Organization",
-  **{"name": "beda.software", "active": False}
+  **{"name": "beda.software", "active": False, "someAttribute": "attribute value"}
 )
 ```
 
@@ -164,7 +165,7 @@ organization = sdk.client.resource(
 
 **Good**
 ```python
-"Encounter.hasInvoice": {
+"Encounter.has-invoice": {
   "name": "has-invoice",
   #...
 },


### PR DESCRIPTION
Add notes about:

1. Search params and operations paths naming (use dash instead of underscore)
2. Resource creation via dict instead of args